### PR TITLE
fix: Use init() for model loading in RunPod handler

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -3,83 +3,31 @@ import os
 import json
 import requests
 import cv2
-import argparse # Keep for Namespace compatibility if useful
+import argparse
 import glob
 import torch
 import numpy as np
 from torchvision.transforms.functional import normalize
 from basicsr.utils import imwrite, img2tensor, tensor2img
 from basicsr.utils.download_util import load_file_from_url
-from basicsr.utils.misc import gpu_is_available, get_device
+from basicsr.utils.misc import gpu_is_available, get_device as basicsr_get_device # Renamed to avoid conflict
 from scipy.ndimage import gaussian_filter1d
 from facelib.utils.face_restoration_helper import FaceRestoreHelper
 from facelib.utils.misc import is_gray
 from basicsr.utils.video_util import VideoReader, VideoWriter
 from basicsr.utils.registry import ARCH_REGISTRY
-# from torch.hub import download_url_to_file # Already have load_file_from_url
 
-# --- Global Model Initialization START ---
-print("Starting global model initialization...")
-device = get_device()
-print(f"Using device: {device}")
+# --- Global variables to be initialized by init() ---
+device = None
+keep_net = None
+FACELIB_WEIGHTS_DIR = None
+# Store functions in global scope if they depend on init's device or other init'd vars,
+# or if they are just helpers defined within init and need to be accessed by handler.
+# For simplicity, helper functions like interpolate_sequence can be defined globally if they don't depend on init state.
+# set_realesrgan_upsampler depends on device and WEIGHTS_DIR, so it's better to make it accessible after init.
+fn_set_realesrgan_upsampler = None 
 
-# Configuration for models and paths (adapted from hugging_face/app.py)
-MODEL_BASE_URL = "https://github.com/jnjaby/KEEP/releases/download/v1.0.0/"
-WEIGHTS_DIR = "/app/weights/" # Standard directory within the Docker image
-
-# Ensure weights directory exists
-os.makedirs(WEIGHTS_DIR, exist_ok=True)
-os.makedirs(os.path.join(WEIGHTS_DIR, "KEEP"), exist_ok=True)
-os.makedirs(os.path.join(WEIGHTS_DIR, "facelib"), exist_ok=True)
-os.makedirs(os.path.join(WEIGHTS_DIR, "realesrgan"), exist_ok=True)
-
-# Load KEEP model
-keep_model_config = {
-    'architecture': {
-        'img_size': 512, 'emb_dim': 256, 'dim_embd': 512, 'n_head': 8, 'n_layers': 9,
-        'codebook_size': 1024, 'cft_list': ['16', '32', '64'], 'kalman_attn_head_dim': 48,
-        'num_uncertainty_layers': 3, 'cfa_list': ['16', '32'], 'cfa_nhead': 4, 'cfa_dim': 256, 'cond': 1
-    },
-    'checkpoint_url': os.path.join(MODEL_BASE_URL, 'KEEP-b76feb75.pth'),
-    'checkpoint_dir': os.path.join(WEIGHTS_DIR, "KEEP")
-}
-keep_net = ARCH_REGISTRY.get('KEEP')(**keep_model_config['architecture']).to(device)
-keep_ckpt_path = load_file_from_url(url=keep_model_config['checkpoint_url'], model_dir=keep_model_config['checkpoint_dir'], progress=True, file_name=None)
-keep_checkpoint = torch.load(keep_ckpt_path, map_location=device, weights_only=True) # Added map_location
-keep_net.load_state_dict(keep_checkpoint['params_ema'])
-keep_net.eval()
-print("KEEP model loaded.")
-
-# Function to set up RealESRGAN (from hugging_face/app.py)
-def set_realesrgan_upsampler():
-    from basicsr.archs.rrdbnet_arch import RRDBNet
-    from basicsr.utils.realesrgan_utils import RealESRGANer
-    
-    use_half = False
-    if torch.cuda.is_available(): # Check device availability properly
-        if device.type == 'cuda':
-            use_half = True 
-
-    model_path = load_file_from_url(
-        url=os.path.join(MODEL_BASE_URL, 'RealESRGAN_x2plus.pth'),
-        model_dir=os.path.join(WEIGHTS_DIR, "realesrgan"), progress=True, file_name=None
-    )
-    model = RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=23, num_grow_ch=32, scale=2)
-    upsampler = RealESRGANer(scale=2, model_path=model_path, model=model, tile=400, tile_pad=40, pre_pad=0, half=use_half, device=device) # Pass device
-    if device.type == 'cpu':
-        import warnings
-        warnings.warn('RealESRGAN: Running on CPU now! Make sure your PyTorch version matches your CUDA. The unoptimized RealESRGAN is slow on CPU.', category=RuntimeWarning)
-    print("RealESRGAN upsampler initialized.")
-    return upsampler
-
-FACELIB_WEIGHTS_DIR = os.path.join(WEIGHTS_DIR, "facelib")
-load_file_from_url(url=os.path.join(MODEL_BASE_URL, 'detection_Resnet50_Final.pth'), model_dir=FACELIB_WEIGHTS_DIR, progress=True, file_name=None)
-load_file_from_url(url=os.path.join(MODEL_BASE_URL, 'detection_mobilenet0.25_Final.pth'), model_dir=FACELIB_WEIGHTS_DIR, progress=True, file_name=None)
-load_file_from_url(url=os.path.join(MODEL_BASE_URL, 'yolov5n-face.pth'), model_dir=FACELIB_WEIGHTS_DIR, progress=True, file_name=None)
-load_file_from_url(url=os.path.join(MODEL_BASE_URL, 'yolov5l-face.pth'), model_dir=FACELIB_WEIGHTS_DIR, progress=True, file_name=None)
-load_file_from_url(url=os.path.join(MODEL_BASE_URL, 'parsing_parsenet.pth'), model_dir=FACELIB_WEIGHTS_DIR, progress=True, file_name=None)
-print("Facelib helper models downloaded.")
-
+# This helper can remain global if it's self-contained
 def interpolate_sequence(sequence):
     interpolated_sequence = np.copy(sequence)
     missing_indices = np.isnan(sequence)
@@ -89,14 +37,88 @@ def interpolate_sequence(sequence):
         interpolated_sequence[missing_indices] = np.interp(x[missing_indices], x[valid_indices], sequence[valid_indices])
     return interpolated_sequence
 
-print("Global model initialization complete.")
-# --- Global Model Initialization END ---
+MODEL_BASE_URL = "https://github.com/jnjaby/KEEP/releases/download/v1.0.0/"
+WEIGHTS_DIR = "/app/weights/" # Standard directory within the Docker image
+
+def init():
+    global device, keep_net, FACELIB_WEIGHTS_DIR, fn_set_realesrgan_upsampler
+
+    print("Starting model initialization (init function)...")
+    device = basicsr_get_device() # Use the renamed import
+    print(f"Using device: {device}")
+
+    os.makedirs(WEIGHTS_DIR, exist_ok=True)
+    os.makedirs(os.path.join(WEIGHTS_DIR, "KEEP"), exist_ok=True)
+    FACELIB_WEIGHTS_DIR_local = os.path.join(WEIGHTS_DIR, "facelib") # Assign to local then global
+    os.makedirs(FACELIB_WEIGHTS_DIR_local, exist_ok=True)
+    os.makedirs(os.path.join(WEIGHTS_DIR, "realesrgan"), exist_ok=True)
+    FACELIB_WEIGHTS_DIR = FACELIB_WEIGHTS_DIR_local
+
+
+    keep_model_config = {
+        'architecture': {
+            'img_size': 512, 'emb_dim': 256, 'dim_embd': 512, 'n_head': 8, 'n_layers': 9,
+            'codebook_size': 1024, 'cft_list': ['16', '32', '64'], 'kalman_attn_head_dim': 48,
+            'num_uncertainty_layers': 3, 'cfa_list': ['16', '32'], 'cfa_nhead': 4, 'cfa_dim': 256, 'cond': 1
+        },
+        'checkpoint_url': os.path.join(MODEL_BASE_URL, 'KEEP-b76feb75.pth'),
+        'checkpoint_dir': os.path.join(WEIGHTS_DIR, "KEEP")
+    }
+    
+    loaded_keep_net = ARCH_REGISTRY.get('KEEP')(**keep_model_config['architecture']).to(device)
+    keep_ckpt_path = load_file_from_url(url=keep_model_config['checkpoint_url'], model_dir=keep_model_config['checkpoint_dir'], progress=True, file_name=None)
+    keep_checkpoint = torch.load(keep_ckpt_path, map_location=device, weights_only=True)
+    loaded_keep_net.load_state_dict(keep_checkpoint['params_ema'])
+    loaded_keep_net.eval()
+    keep_net = loaded_keep_net # Assign to global
+    print("KEEP model loaded.")
+
+    # Define set_realesrgan_upsampler within init or make it accessible via global fn_
+    def _set_realesrgan_upsampler_internal(): # Underscore to indicate it's meant for internal use or to be wrapped
+        from basicsr.archs.rrdbnet_arch import RRDBNet
+        from basicsr.utils.realesrgan_utils import RealESRGANer
+        
+        use_half = False
+        if device.type == 'cuda': # Check device availability properly
+            use_half = True 
+
+        model_path = load_file_from_url(
+            url=os.path.join(MODEL_BASE_URL, 'RealESRGAN_x2plus.pth'),
+            model_dir=os.path.join(WEIGHTS_DIR, "realesrgan"), progress=True, file_name=None
+        )
+        model = RRDBNet(num_in_ch=3, num_out_ch=3, num_feat=64, num_block=23, num_grow_ch=32, scale=2)
+        upsampler = RealESRGANer(scale=2, model_path=model_path, model=model, tile=400, tile_pad=40, pre_pad=0, half=use_half, device=device)
+        if device.type == 'cpu':
+            import warnings
+            warnings.warn('RealESRGAN: Running on CPU now!', category=RuntimeWarning)
+        print("RealESRGAN upsampler initialized by factory function.")
+        return upsampler
+    
+    fn_set_realesrgan_upsampler = _set_realesrgan_upsampler_internal # Assign the function itself to global
+
+    load_file_from_url(url=os.path.join(MODEL_BASE_URL, 'detection_Resnet50_Final.pth'), model_dir=FACELIB_WEIGHTS_DIR, progress=True, file_name=None)
+    load_file_from_url(url=os.path.join(MODEL_BASE_URL, 'detection_mobilenet0.25_Final.pth'), model_dir=FACELIB_WEIGHTS_DIR, progress=True, file_name=None)
+    load_file_from_url(url=os.path.join(MODEL_BASE_URL, 'yolov5n-face.pth'), model_dir=FACELIB_WEIGHTS_DIR, progress=True, file_name=None)
+    load_file_from_url(url=os.path.join(MODEL_BASE_URL, 'yolov5l-face.pth'), model_dir=FACELIB_WEIGHTS_DIR, progress=True, file_name=None)
+    load_file_from_url(url=os.path.join(MODEL_BASE_URL, 'parsing_parsenet.pth'), model_dir=FACELIB_WEIGHTS_DIR, progress=True, file_name=None)
+    print("Facelib helper models downloaded.")
+    print("Model initialization (init function) complete.")
+    # No return value needed if using globals
+
+# --- enhance_video_file function (uses global model variables) ---
+# This function's definition remains largely the same,
+# but it will now implicitly use global `device`, `keep_net`, `FACELIB_WEIGHTS_DIR`, 
+# and `fn_set_realesrgan_upsampler`.
+# Ensure all references to these are direct (e.g., `keep_net` not `context.keep_net`)
 
 def enhance_video_file(input_video_path, output_dir, job_input):
+    # Uses global: device, keep_net (as net), FACELIB_WEIGHTS_DIR, fn_set_realesrgan_upsampler
+    # Uses global helper: interpolate_sequence
+
     args = argparse.Namespace(
         input_path=input_video_path, 
         upscale=1, 
-        max_length=job_input.get('max_processing_length', 200), # Allow longer processing, default 20 from original, 200 for serverless
+        max_processing_length=job_input.get('max_processing_length', 200),
         has_aligned=job_input.get('has_aligned', False),
         only_center_face=job_input.get('only_center_face', True),
         draw_box=job_input.get('draw_box', False),
@@ -111,15 +133,15 @@ def enhance_video_file(input_video_path, output_dir, job_input):
 
     os.makedirs(output_dir, exist_ok=True)
 
-    bg_upsampler_instance = None # Renamed to avoid conflict with global function name
+    bg_upsampler_instance = None
     if args.bg_enhancement:
-        bg_upsampler_instance = set_realesrgan_upsampler() 
+        bg_upsampler_instance = fn_set_realesrgan_upsampler() # Call the global function
     
-    face_upsampler_instance = None # Renamed
+    face_upsampler_instance = None
     if args.face_upsample:
-        face_upsampler_instance = bg_upsampler_instance if bg_upsampler_instance is not None else set_realesrgan_upsampler()
+        face_upsampler_instance = bg_upsampler_instance if bg_upsampler_instance is not None else fn_set_realesrgan_upsampler() # Call the global function
 
-    net = keep_net 
+    net = keep_net # Use global keep_net
     
     print(f"Processing video: {args.input_path}")
     if not args.has_aligned:
@@ -136,8 +158,8 @@ def enhance_video_file(input_video_path, output_dir, job_input):
         det_model=args.detection_model, 
         save_ext='png', 
         use_parse=True, 
-        device=device,
-        model_rootpath=FACELIB_WEIGHTS_DIR 
+        device=device, # Use global device
+        model_rootpath=FACELIB_WEIGHTS_DIR # Use global FACELIB_WEIGHTS_DIR
     )
 
     input_img_list = []
@@ -165,102 +187,112 @@ def enhance_video_file(input_video_path, output_dir, job_input):
         for i, img in enumerate(input_img_list):
             face_helper.clean_all()
             face_helper.read_image(img)
-            num_det_faces = face_helper.get_face_landmarks_5(only_center_face=args.only_center_face, resize=640, eye_dist_threshold=5, only_keep_largest=True)
-            if num_det_faces == 1:
-                raw_landmarks.append(face_helper.all_landmarks_5[0].reshape((10,)))
-            elif num_det_faces == 0:
-                raw_landmarks.append(np.array([np.nan]*10))
-            else: # Multiple faces detected, pick the first one for simplicity in serverless
-                print(f"Warning: Multiple faces ({num_det_faces}) detected in frame {i}. Using the first one.")
-                raw_landmarks.append(face_helper.all_landmarks_5[0].reshape((10,)))
+            # Pass detect_condition to ensure it's a number
+            num_det_faces = face_helper.get_face_landmarks_5(only_center_face=args.only_center_face, resize=640, eye_dist_threshold=5, only_keep_largest=True, detect_condition=0)
 
+            if num_det_faces >= 1: # If any face is detected
+                 raw_landmarks.append(face_helper.all_landmarks_5[0].reshape((10,)))
+            else: # num_det_faces == 0
+                 raw_landmarks.append(np.array([np.nan]*10))
+        
         raw_landmarks = np.array(raw_landmarks)
-        for i_lm in range(raw_landmarks.shape[1]): # Iterate over landmark coordinates
-            raw_landmarks[:, i_lm] = interpolate_sequence(raw_landmarks[:, i_lm]) 
-        video_length = len(input_img_list)
-        avg_landmarks = gaussian_filter1d(raw_landmarks, 5, axis=0).reshape(video_length, 5, 2)
+        for i_lm in range(raw_landmarks.shape[1]): 
+            raw_landmarks[:, i_lm] = interpolate_sequence(raw_landmarks[:, i_lm]) # Uses global interpolate_sequence
+        video_length_raw = len(input_img_list) # Renamed to avoid conflict
+        avg_landmarks = gaussian_filter1d(raw_landmarks, 5, axis=0).reshape(video_length_raw, 5, 2)
     
     cropped_faces = []
     for i, img in enumerate(input_img_list):
         face_helper.clean_all()
         face_helper.read_image(img)
-        if not args.has_aligned: # Use avg_landmarks if alignment was performed
+        if not args.has_aligned: 
              face_helper.all_landmarks_5 = [avg_landmarks[i]]
-        # If args.has_aligned is true, the original app.py assumes faces are already cropped and aligned.
-        # This part of logic might need more complex handling if has_aligned is true for serverless.
-        # For now, proceed assuming align_warp_face is always needed if not pre-aligned.
+        
         face_helper.align_warp_face() 
         if not face_helper.cropped_faces:
-            # Fallback: if no face is cropped (e.g. alignment failed), skip frame or use placeholder
-            # For now, creating a dummy black image tensor to avoid crash
             print(f"Warning: No face cropped for frame {i}. Using a black placeholder.")
-            cropped_faces.append(torch.zeros(3, 512, 512, dtype=torch.float32, device=device) * -1) # Normalized to -1 to 1 range
+            # Ensure placeholder tensor is on the correct device
+            cropped_faces.append(torch.zeros(3, 512, 512, dtype=torch.float32, device=device) * -1) 
             continue
 
         cropped_face_t = img2tensor(face_helper.cropped_faces[0] / 255., bgr2rgb=True, float32=True)
         normalize(cropped_face_t, (0.5, 0.5, 0.5), (0.5, 0.5, 0.5), inplace=True)
-        cropped_faces.append(cropped_face_t)
+        cropped_faces.append(cropped_face_t) # Appending tensor, not list
         
-    if not cropped_faces: # If all frames failed cropping
+    if not cropped_faces: 
         raise ValueError("Could not crop any faces from the video.")
 
-    cropped_faces = torch.stack(cropped_faces, dim=0).unsqueeze(0).to(device)
+    # Make sure all items in cropped_faces are tensors before stacking
+    if not all(isinstance(cf, torch.Tensor) for cf in cropped_faces):
+        raise TypeError("Not all cropped faces are tensors, check placeholder logic.")
+
+    cropped_faces_tensor = torch.stack(cropped_faces, dim=0).unsqueeze(0).to(device) # Renamed variable
     
     print('Restoring faces ...')
     with torch.no_grad():
-        video_length = cropped_faces.shape[1]
+        video_length_restored = cropped_faces_tensor.shape[1] # Renamed
         output_frames_list = [] 
-        for start_idx in range(0, video_length, args.max_length):
-            end_idx = min(start_idx + args.max_length, video_length)
-            current_segment_input = cropped_faces[:, start_idx:end_idx, ...]
-            if current_segment_input.shape[1] == 0: # Skip if segment is empty
+        for start_idx in range(0, video_length_restored, args.max_processing_length): # Use max_processing_length
+            end_idx = min(start_idx + args.max_processing_length, video_length_restored) # Use max_processing_length
+            current_segment_input = cropped_faces_tensor[:, start_idx:end_idx, ...]
+            
+            if current_segment_input.shape[1] == 0: 
                 continue
-            if current_segment_input.shape[1] == 1 and start_idx+1 < video_length : # Original bug: if end_idx-start_idx == 1
-                 # Duplicate frame for sequence if it's a single frame segment AND not the very last frame of video
-                output_frames_list.append(net(current_segment_input.repeat(1,2,1,1,1), need_upscale=False)[:, 0:1, ...])
-            elif current_segment_input.shape[1] == 1 and start_idx+1 >= video_length: # Very last frame is single
-                output_frames_list.append(net(current_segment_input, need_upscale=False))
+            
+            # Adjusted logic for single frame segments
+            if current_segment_input.shape[1] == 1:
+                # If it's a single frame segment, duplicate it to form a sequence of 2, then take the first output.
+                # This is a common trick if models expect sequences.
+                # However, the KEEP model might handle single frames if its architecture supports it.
+                # The original logic was:
+                # if end_idx - start_idx == 1: output.append(net(cropped_faces[:, [start_idx, start_idx], ...])[:, 0:1, ...])
+                # This implies duplicating the frame if the segment length is 1.
+                duplicated_input = current_segment_input.repeat(1,2,1,1,1)
+                output_segment = net(duplicated_input, need_upscale=False)[:, 0:1, ...] # Take first frame output
             else:
-                output_frames_list.append(net(current_segment_input, need_upscale=False))
+                output_segment = net(current_segment_input, need_upscale=False)
+            output_frames_list.append(output_segment)
         
         if not output_frames_list:
              raise ValueError("No output frames generated by the KEEP model.")
 
         output_tensor = torch.cat(output_frames_list, dim=1).squeeze(0) 
-        # Expected: output_tensor.shape[0] == video_length (number of cropped faces)
-        # Actual: output_tensor.shape[0] might be less if some input frames didn't yield a face
-        # We need to match restored_faces with input_img_list, so length must be same as original video_length
-        # This is tricky if face detection failed for some frames.
-        # For now, assuming output_tensor.shape[0] matches number of successfully cropped_faces.
-        # The pasting logic needs to handle this carefully.
         
-        # Assuming restored_faces count matches cropped_faces count.
         restored_faces = [tensor2img(x, rgb2bgr=True, min_max=(-1, 1)) for x in output_tensor]
         del output_tensor 
         torch.cuda.empty_cache() 
 
     print('Pasting faces back ...')
     restored_frames_final_list = []
-    # Iterate through original input_img_list to ensure output video has same number of frames
-    # And use avg_landmarks that corresponds to original frame indices
-    face_idx_counter = 0 # To map restored_faces to original frames where faces were found
+    face_idx_counter = 0 
     for i, img_original in enumerate(input_img_list):
         face_helper.clean_all()
         
-        # Check if a face was successfully processed for this original frame 'i'
-        # This requires knowing if avg_landmarks[i] was valid and resulted in a cropped_face
-        # This is a simplification: assumes if avg_landmarks[i] is not NaN, a face was processed.
-        # A more robust way would be to track indices of successfully cropped faces.
-        is_face_processed_for_this_frame = not np.isnan(avg_landmarks[i]).any() if not args.has_aligned else True
+        is_face_processed_for_this_frame = False
+        if not args.has_aligned:
+            # Check if avg_landmarks[i] was valid (not NaN) AND resulted in a successfully cropped face earlier
+            # This requires that cropped_faces list corresponds index-wise to input_img_list for placeholders
+            if i < len(avg_landmarks) and not np.isnan(avg_landmarks[i]).any():
+                # Additionally, check if the corresponding entry in cropped_faces was not a placeholder
+                # This check is imperfect as the placeholder is also a tensor.
+                # A better way would be to have a parallel list of booleans indicating success of cropping.
+                # For now, assume if landmarks were not NaN, a face was attempted.
+                is_face_processed_for_this_frame = True 
+        else: # has_aligned == True
+            is_face_processed_for_this_frame = True
+
 
         if not is_face_processed_for_this_frame or face_idx_counter >= len(restored_faces):
-            # If no face was processed or we've run out of restored_faces (shouldn't happen if logic is tight)
-            # Use original frame or a black frame. For now, use original.
-            print(f"Warning: No restored face for frame {i}. Using original frame.")
-            if args.bg_enhancement and bg_upsampler_instance: # Still apply BG enhancement if requested
+            print(f"Warning: No restored face for frame {i} or ran out of restored faces. Using original frame.")
+            if args.bg_enhancement and bg_upsampler_instance: 
                 restored_frames_final_list.append(bg_upsampler_instance.enhance(img_original, outscale=args.upscale)[0])
             else:
                 restored_frames_final_list.append(img_original)
+            if not is_face_processed_for_this_frame: # Only skip incrementing face_idx_counter if this frame was skipped for face processing
+                pass # Do not increment face_idx_counter
+            else: # Ran out of restored faces (should not happen)
+                face_idx_counter +=1
+
             continue
 
         current_restored_face = restored_faces[face_idx_counter]
@@ -270,15 +302,13 @@ def enhance_video_file(input_video_path, output_dir, job_input):
             img_resized_for_pasting = cv2.resize(img_original, (512, 512), interpolation=cv2.INTER_LINEAR)
             face_helper.is_gray = is_gray(img_resized_for_pasting, threshold=10)
             if face_helper.is_gray: print('Grayscale input: True')
-            face_helper.cropped_faces = [img_resized_for_pasting] # Provide the background
+            face_helper.cropped_faces = [img_resized_for_pasting] 
             face_helper.add_restored_face(current_restored_face.astype('uint8'))
-            # For aligned, paste onto this resized image.
             pasted_img = face_helper.paste_faces_to_input_image(upsample_img=img_resized_for_pasting, draw_box=args.draw_box)
         else:
-            face_helper.read_image(img_original) # Use original image for pasting
-            face_helper.all_landmarks_5 = [avg_landmarks[i]] # Use landmarks for this specific frame
-            # No align_warp_face here, that was for cropping. We need to paste back.
-            face_helper.add_restored_face(current_restored_face.astype('uint8')) # Add the processed face
+            face_helper.read_image(img_original) 
+            face_helper.all_landmarks_5 = [avg_landmarks[i]] 
+            face_helper.add_restored_face(current_restored_face.astype('uint8')) 
             
             bg_img_upsampled_for_paste = None
             if bg_upsampler_instance is not None:
@@ -307,7 +337,8 @@ def enhance_video_file(input_video_path, output_dir, job_input):
     
     vidwriter = VideoWriter(save_restore_path, height, width, fps)
     for f_idx, f_frame in enumerate(restored_frames_final_list):
-        if f_frame is None: # Should be caught by above check, but defensive
+        if f_frame is None: 
+            print(f"Warning: Frame {f_idx} is None during saving. Using black frame.")
             f_frame = np.zeros((height, width, 3), dtype=np.uint8)
         vidwriter.write_frame(f_frame)
     vidwriter.close()
@@ -315,7 +346,13 @@ def enhance_video_file(input_video_path, output_dir, job_input):
     print(f'All results saved in {save_restore_path}.')
     return save_restore_path
 
+
+# --- Main Handler ---
 def handler(job):
+    # This function now assumes init() has been called and populated globals:
+    # device, keep_net, FACELIB_WEIGHTS_DIR, fn_set_realesrgan_upsampler
+    # It also uses global helper: interpolate_sequence (implicitly via enhance_video_file)
+
     print("Received job:", job)
     job_input = job.get('input', {})
     if not job_input:
@@ -327,20 +364,16 @@ def handler(job):
 
     print(f"Received video_url: {video_url}")
     job_id = job.get("id", "temp_video_job") 
-    # Sanitize job_id for use in paths if necessary, or use a UUID
-    # For simplicity, assume job_id is safe or RunPod provides a safe one.
-    base_tmp_dir = "/tmp/runpod_jobs/" # Use /tmp for temporary files
+    
+    base_tmp_dir = "/tmp/runpod_jobs/" 
     os.makedirs(base_tmp_dir, exist_ok=True)
-
     local_video_path = os.path.join(base_tmp_dir, f"{job_id}_downloaded.mp4")
-    # Output dir also in /tmp, RunPod handles persistence if configured for output
     output_dir = os.path.join(base_tmp_dir, f"{job_id}_output/") 
     os.makedirs(output_dir, exist_ok=True)
 
-
     try:
         print(f"Downloading video from {video_url} to {local_video_path}...")
-        response = requests.get(video_url, stream=True, timeout=60) # Added timeout
+        response = requests.get(video_url, stream=True, timeout=60) 
         response.raise_for_status()
         with open(local_video_path, 'wb') as f:
             for chunk in response.iter_content(chunk_size=8192):
@@ -348,11 +381,10 @@ def handler(job):
         print(f"Video downloaded successfully to {local_video_path}")
 
         print("Starting video enhancement process...")
+        # Ensure enhance_video_file is called correctly
         processed_video_path = enhance_video_file(local_video_path, output_dir, job_input)
         print(f"Video enhancement complete. Output: {processed_video_path}")
         
-        # The processed_video_path is what RunPod will serve or expect as output.
-        # Ensure it's a path accessible within the container.
         return {
             "success": True,
             "message": "Video processed successfully.",
@@ -368,7 +400,7 @@ def handler(job):
     except TypeError as e: 
         print(f"Type error during processing: {e}")
         return {"error": f"Type error during processing: {str(e)}"}
-    except ValueError as e: # Catch ValueErrors from processing logic
+    except ValueError as e: 
         print(f"ValueError during processing: {e}")
         return {"error": f"ValueError during processing: {str(e)}"}
     except Exception as e:
@@ -383,17 +415,12 @@ def handler(job):
                 print(f"Cleaned up downloaded file: {local_video_path}")
             except Exception as e_clean:
                 print(f"Error cleaning up file {local_video_path}: {e_clean}")
-        # Consider cleaning up output_dir if it's not automatically handled by RunPod for job outputs
-        # For now, leave it, as RunPod might need it to serve the result.
-        # if os.path.exists(output_dir):
-        #    try:
-        #        import shutil
-        #        shutil.rmtree(output_dir)
-        #        print(f"Cleaned up output directory: {output_dir}")
-        #    except Exception as e_clean_dir:
-        #        print(f"Error cleaning up directory {output_dir}: {e_clean_dir}")
+        # Note: output_dir is not cleaned up, assuming RunPod handles it or it's desired.
 
 
 if __name__ == '__main__':
-    print("Starting RunPod worker for KEEP model via __main__...")
-    runpod.serverless.start({"handler": handler})
+    print("Starting RunPod worker for KEEP model with init function...")
+    runpod.serverless.start({
+        "handler": handler,
+        "init": init  # Pass the init function to RunPod
+    })


### PR DESCRIPTION
Refactored `handler.py` to move all model loading and initialization logic into an `init()` function, as expected by the RunPod serverless environment. Models and shared resources are now stored as global variables populated by `init()`.

This change aims to resolve issues where I might exit prematurely (exit code 0) due to model loading times exceeding implicit startup timeouts. By using `init()`, RunPod can manage the initialization phase explicitly.